### PR TITLE
Improve documentation for Spring Boot Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ Add the following import and script either to a SuiteSetup page or to the test p
 
 ```java
 import static com.bigdullrock.fitnesse.spring.SpringContextFactory.currentSpringContext;
+// or use the following import for Spring Boot applications
+// import static com.bigdullrock.fitnesse.spring.SpringBootContextFactory.currentSpringContext;
 
 import org.springframework.beans.factory.annotation.Autowired;
 


### PR DESCRIPTION
In case of Spring Boot application, the code example of the fixture is slightly different. The difference is so small that it is hard to catch. I tried to improve the Readme by adding a comment in the fixture code example to document that difference and call developer eyes to that place.